### PR TITLE
Change the address pin system

### DIFF
--- a/src/construction.rs
+++ b/src/construction.rs
@@ -4,7 +4,7 @@ extern crate embedded_hal as hal;
 use core::marker::PhantomData;
 use hal::blocking;
 use interface::I2cInterface;
-use {ic, mode, Ads1x1x, Config, FullScaleRange, SlaveAddr, DEVICE_BASE_ADDRESS};
+use {ic, mode, Ads1x1x, Config, FullScaleRange, SlaveAddr};
 
 macro_rules! impl_new_destroy {
     ( $IC:ident, $create:ident, $destroy:ident, $conv:ty ) => {
@@ -17,7 +17,7 @@ macro_rules! impl_new_destroy {
                 Ads1x1x {
                     iface: I2cInterface {
                         i2c,
-                        address: address.addr(DEVICE_BASE_ADDRESS),
+                        address: address as u8,
                     },
                     config: Config::default(),
                     fsr: FullScaleRange::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,15 +388,6 @@ impl Default for SlaveAddr {
     }
 }
 
-//impl SlaveAddr {
-//    fn addr(self, default: u8) -> u8 {
-//        match self {
-//            SlaveAddr::Default => default,
-//            SlaveAddr::Alternative(a1, a0) => default | ((a1 as u8) << 1) | a0 as u8,
-//        }
-//    }
-//}
-
 struct Register;
 
 impl Register {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,6 @@ pub enum ModeChangeError<E, DEV> {
     I2C(E, DEV),
 }
 
-const DEVICE_BASE_ADDRESS: u8 = 0b100_1000;
-
 /// Mode marker types
 pub mod mode {
     /// One-shot operating mode / power-down state (default)
@@ -368,30 +366,36 @@ pub enum FullScaleRange {
     Within0_256V,
 }
 
-/// Possible slave addresses
+/// Possible device slace addresses, based on which which pin the ADDR pin is
+/// wired to. Reference Table 4 of the datasheet.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(u8)]
 pub enum SlaveAddr {
-    /// Default slave address
-    Default,
-    /// Alternative slave address providing bit values for A1 and A0
-    Alternative(bool, bool),
+    /// GND pin: 0x48
+    Gnd = 0b100_1000,
+    /// VDD pin: 0x49
+    Vdd = 0b100_1001,
+    /// SDA pin: 0x50
+    Sda = 0b100_1010,
+    /// SCL pin: 0x51
+    Scl = 0b100_1011,
 }
 
 impl Default for SlaveAddr {
     /// Default slave address
     fn default() -> Self {
-        SlaveAddr::Default
+        SlaveAddr::Gnd
     }
 }
 
-impl SlaveAddr {
-    fn addr(self, default: u8) -> u8 {
-        match self {
-            SlaveAddr::Default => default,
-            SlaveAddr::Alternative(a1, a0) => default | ((a1 as u8) << 1) | a0 as u8,
-        }
-    }
-}
+//impl SlaveAddr {
+//    fn addr(self, default: u8) -> u8 {
+//        match self {
+//            SlaveAddr::Default => default,
+//            SlaveAddr::Alternative(a1, a0) => default | ((a1 as u8) << 1) | a0 as u8,
+//        }
+//    }
+//}
 
 struct Register;
 


### PR DESCRIPTION
I think this system is easier to understand, from the perspective of the datasheet, from how you wire the device, and from existing guides on the internet. `SlaveAddr` is now a u8-repr enum with 4 possible values, corresponding to Table 4 of [the datasheet](https://www.ti.com/lit/ds/symlink/ads1115.pdf).