### PR TITLE
Simplify `SlaveAddr`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add default for `ComparatorQueue`.
 
 ### Changed
-- Updated `embedded-hal` to version `1`, `read` in one-shot mode is therefore only an inherent method.
+- [breaking-change] Updated `embedded-hal` to version `1`, `read` in one-shot mode is therefore only an inherent method.
+- [breaking-change] Simplified `SlaveAddr` enum.
 - Raised MSRV to 1.62.0.
-- Simplified `SlaveAddr` enum.
 
 ### Removed
 - Removed `I2cInterface`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated `embedded-hal` to version `1`, `read` in one-shot mode is therefore only an inherent method.
 - Raised MSRV to 1.62.0.
+- Simplified `SlaveAddr` enum.
 
 ### Removed
 - Removed `I2cInterface`.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ use ads1x1x::{channel, Ads1x1x, SlaveAddr};
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let address = SlaveAddr::default();
-    let mut adc = Ads1x1x::new_ads1013(dev, address);
+    let mut adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
     let value = block!(adc.read(channel::DifferentialA0A1)).unwrap();
     println!("Measurement: {}", value);
     // get I2C device back

--- a/examples/all_channels.rs
+++ b/examples/all_channels.rs
@@ -5,8 +5,7 @@ use ads1x1x::{channel, Ads1x1x, SlaveAddr};
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let address = SlaveAddr::default();
-    let mut adc = Ads1x1x::new_ads1015(dev, address);
+    let mut adc = Ads1x1x::new_ads1015(dev, SlaveAddr::default());
     let values = [
         block!(adc.read(channel::SingleA0)).unwrap(),
         block!(adc.read(channel::SingleA1)).unwrap(),

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -5,8 +5,7 @@ use ads1x1x::{channel, Ads1x1x, SlaveAddr};
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let address = SlaveAddr::default();
-    let mut adc = Ads1x1x::new_ads1013(dev, address);
+    let mut adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
     let value = block!(adc.read(channel::DifferentialA0A1)).unwrap();
     println!("Measurement: {}", value);
     // get I2C device back

--- a/examples/trait.rs
+++ b/examples/trait.rs
@@ -14,8 +14,7 @@ pub fn read<E, A: DynamicOneShot<Error = E>>(adc: &mut A) -> i16 {
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let address = SlaveAddr::default();
-    let mut adc = Ads1x1x::new_ads1115(dev, address);
+    let mut adc = Ads1x1x::new_ads1115(dev, SlaveAddr::default());
 
     let value = read(&mut adc);
     println!("Measurement: {}", value);

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -21,8 +21,7 @@ pub fn read(adc: &mut Adc) -> i16 {
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let address = SlaveAddr::default();
-    let mut adc = Ads1x1x::new_ads1115(dev, address);
+    let mut adc = Ads1x1x::new_ads1115(dev, SlaveAddr::default());
 
     let value = read(&mut adc);
     println!("Measurement: {}", value);

--- a/src/construction.rs
+++ b/src/construction.rs
@@ -1,6 +1,6 @@
 //! Constructor/destructor functions.
 
-use crate::{ic, mode, Ads1x1x, Config, FullScaleRange, SlaveAddr, DEVICE_BASE_ADDRESS};
+use crate::{ic, mode, Ads1x1x, Config, FullScaleRange, SlaveAddr};
 use core::marker::PhantomData;
 
 macro_rules! impl_new_destroy {
@@ -13,7 +13,7 @@ macro_rules! impl_new_destroy {
             pub fn $create(i2c: I2C, address: SlaveAddr) -> Self {
                 Ads1x1x {
                     i2c,
-                    address: address.addr(DEVICE_BASE_ADDRESS),
+                    address: address.bits(),
                     config: Config::default(),
                     fsr: FullScaleRange::default(),
                     a_conversion_was_started: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,46 +84,28 @@
 //!
 //! [driver-examples]: https://github.com/eldruin/driver-examples
 //!
-//! ### Create a driver instance for the ADS1013
+//! ### Create a driver instance for an ADS1013 with the default address.
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
 //! use ads1x1x::{Ads1x1x, SlaveAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let address = SlaveAddr::default();
-//! let adc = Ads1x1x::new_ads1013(dev, address);
+//! let adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
 //! // do something...
 //!
 //! // get the I2C device back
 //! let dev = adc.destroy_ads1013();
 //! ```
 //!
-//! ### Create a driver instance for the ADS1013 with an alternative address (method 1)
+//! ### Create a driver instance for an ADS1013 with the ADDR pin connected to SDA.
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
 //! use ads1x1x::{Ads1x1x, SlaveAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let (bit1, bit0) = (true, false); // last two bits of address
-//! let address = SlaveAddr::Alternative(bit1, bit0);
-//! let adc = Ads1x1x::new_ads1013(dev, address);
-//! ```
-
-//! ### Create a driver instance for the ADS1013 with an alternative address (method 2)
-//!
-//! Using helper `SlaveAddr` creation method depending on the connection of
-//! the `ADDR` pin.
-//!
-//! ```no_run
-//! use linux_embedded_hal::I2cdev;
-//! use ads1x1x::{Ads1x1x, SlaveAddr};
-//!
-//! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! // `ADDR` pin connected to SDA results in the 0x4A effective address
-//! let address = SlaveAddr::new_sda();
-//! let adc = Ads1x1x::new_ads1013(dev, address);
+//! let adc = Ads1x1x::new_ads1013(dev, SlaveAddr::Sda);
 //! ```
 //!
 //! ### Make a one-shot measurement
@@ -149,8 +131,7 @@
 //! use ads1x1x::{Ads1x1x, ModeChangeError, SlaveAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let address = SlaveAddr::default();
-//! let adc = Ads1x1x::new_ads1013(dev, address);
+//! let adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
 //! match adc.into_continuous() {
 //!     Err(ModeChangeError::I2C(e, adc)) => /* mode change failed handling */ panic!(),
 //!     Ok(mut adc) => {
@@ -170,8 +151,7 @@
 //! use ads1x1x::{Ads1x1x, DataRate16Bit, SlaveAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let address = SlaveAddr::default();
-//! let mut adc = Ads1x1x::new_ads1115(dev, address);
+//! let mut adc = Ads1x1x::new_ads1115(dev, SlaveAddr::default());
 //! adc.set_data_rate(DataRate16Bit::Sps860).unwrap();
 //! ```
 //!
@@ -203,8 +183,6 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![no_std]
-
-const DEVICE_BASE_ADDRESS: u8 = 0b100_1000;
 
 struct Register;
 impl Register {


### PR DESCRIPTION
None of the datasheets mention “alternative” in respect to addresses, so I am not sure why they were named like this.
