### PR TITLE
Remove `reset_internal_driver_state`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - Removed `I2cInterface`.
+- Removed `reset_internal_driver_state` method.
 
 ## [0.2.2] - 2021-07-29
 

--- a/src/devices/common.rs
+++ b/src/devices/common.rs
@@ -37,19 +37,4 @@ where
         };
         Ok(!config.is_high(BitFlags::OS))
     }
-
-    /// Reset the internal state of this driver to the default values.
-    ///
-    /// *Note:* This does not alter the state or configuration of the device.
-    ///
-    /// This resets the cached configuration register value in this driver to
-    /// the power-up (reset) configuration of the device.
-    ///
-    /// This needs to be called after performing a reset on the device, for
-    /// example through an I2C general-call Reset command, which was not done
-    /// through this driver to ensure that the configurations in the device
-    /// and in the driver match.
-    pub fn reset_internal_driver_state(&mut self) {
-        self.config = Config::default();
-    }
 }


### PR DESCRIPTION
A device can already be reset by destroying and recreating it. Also, calling `reset_internal_driver_state` in `Continuous` mode is wrong, since the device will be in `OneShot` mode after a reset.
