### PR TITLE
Make `FullScaleRange` docs consistent.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -151,7 +151,7 @@ pub enum FullScaleRange {
     Within6_144V,
     /// ±4.096V
     Within4_096V,
-    /// The measurable range is ±2.048V. (default)
+    /// ±2.048V (default)
     #[default]
     Within2_048V,
     /// ±1.024V


### PR DESCRIPTION
Somehow messed up the rebase in https://github.com/eldruin/ads1x1x-rs/pull/18 which left this line unchanged.