### PR TITLE
Set comparator to default on continuous pulse

### DIFF
--- a/src/devices/features/tier2.rs
+++ b/src/devices/features/tier2.rs
@@ -143,7 +143,7 @@ where
     /// provides a continuous-conversion ready pulse when in
     /// continuous-conversion mode.
     ///
-    /// When calling this the comparator will be disabled and the thresholds will be cleared.
+    /// When calling this the comparator will be reset to default and the thresholds will be cleared.
     pub fn use_alert_rdy_pin_as_ready(&mut self) -> Result<(), Error<E>> {
         if self.config
             != self
@@ -151,7 +151,7 @@ where
                 .with_high(BF::COMP_QUE1)
                 .with_high(BF::COMP_QUE0)
         {
-            self.disable_comparator()?;
+            self.set_comparator_queue(ComparatorQueue::default())?;
         }
         self.write_register(Register::HIGH_TH, 0x8000)?;
         self.write_register(Register::LOW_TH, 0)


### PR DESCRIPTION
Took longer than I expected to find the time to submit this change, but it's to fix #26

@eldruin - Going to be honest, I have no idea what those tests you mentioned in that issue are suppose to do in this particular case. It looks like it's suppose to check that it doesn't break the boards that don't use it as a conversion-ready pulse? But I'm not sure this function call would be appropriate at all for those boards that don't support it anyways.