### PR TITLE
Update the terms "master/slave" to "controller/target" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- [breaking-change] Changed the terms "master/slave" to "controller/target" to align with the i2c bus specification v.7
+- [breaking-change] Changed the terms "master/slave" to "controller/target" to align with the I2C bus specification v.7
 
 ### Added
 - Derived common traits for types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- [breaking-change] Changed the terms "master/slave" to "controller/target" to align with the i2c bus specification v.7
+
 ### Added
 - Derived common traits for types.
 - Add default for `ComparatorQueue`.

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ Please find additional examples using hardware in this repository: [driver-examp
 use linux_embedded_hal::I2cdev;
 use nb::block;
 
-use ads1x1x::{channel, Ads1x1x, SlaveAddr};
+use ads1x1x::{channel, Ads1x1x, TargetAddr};
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let mut adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
+    let mut adc = Ads1x1x::new_ads1013(dev, TargetAddr::default());
     let value = block!(adc.read(channel::DifferentialA0A1)).unwrap();
     println!("Measurement: {}", value);
     // get I2C device back

--- a/examples/all_channels.rs
+++ b/examples/all_channels.rs
@@ -1,11 +1,11 @@
 use linux_embedded_hal::I2cdev;
 use nb::block;
 
-use ads1x1x::{channel, Ads1x1x, SlaveAddr};
+use ads1x1x::{channel, Ads1x1x, TargetAddr};
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let mut adc = Ads1x1x::new_ads1015(dev, SlaveAddr::default());
+    let mut adc = Ads1x1x::new_ads1015(dev, TargetAddr::default());
     let values = [
         block!(adc.read(channel::SingleA0)).unwrap(),
         block!(adc.read(channel::SingleA1)).unwrap(),

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -1,11 +1,11 @@
 use linux_embedded_hal::I2cdev;
 use nb::block;
 
-use ads1x1x::{channel, Ads1x1x, SlaveAddr};
+use ads1x1x::{channel, Ads1x1x, TargetAddr};
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let mut adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
+    let mut adc = Ads1x1x::new_ads1013(dev, TargetAddr::default());
     let value = block!(adc.read(channel::DifferentialA0A1)).unwrap();
     println!("Measurement: {}", value);
     // get I2C device back

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -7,7 +7,7 @@ use nb::block;
 use ads1x1x::{
     channel,
     ic::{Ads1115, Resolution16Bit},
-    Ads1x1x, SlaveAddr,
+    Ads1x1x, TargetAddr,
 };
 
 /// Type alias
@@ -21,7 +21,7 @@ pub fn read(adc: &mut Adc) -> i16 {
 
 fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
-    let mut adc = Ads1x1x::new_ads1115(dev, SlaveAddr::default());
+    let mut adc = Ads1x1x::new_ads1115(dev, TargetAddr::default());
 
     let value = read(&mut adc);
     println!("Measurement: {}", value);

--- a/src/construction.rs
+++ b/src/construction.rs
@@ -1,6 +1,6 @@
 //! Constructor/destructor functions.
 
-use crate::{ic, mode, Ads1x1x, Config, FullScaleRange, SlaveAddr};
+use crate::{ic, mode, Ads1x1x, Config, FullScaleRange, TargetAddr};
 use core::marker::PhantomData;
 
 macro_rules! impl_new_destroy {
@@ -10,7 +10,7 @@ macro_rules! impl_new_destroy {
             I2C: embedded_hal::i2c::I2c<Error = E>,
         {
             /// Create a new instance of the device in OneShot mode.
-            pub fn $create(i2c: I2C, address: SlaveAddr) -> Self {
+            pub fn $create(i2c: I2C, address: TargetAddr) -> Self {
                 Ads1x1x {
                     i2c,
                     address: address.bits(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,10 @@
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
-//! use ads1x1x::{Ads1x1x, SlaveAddr};
+//! use ads1x1x::{Ads1x1x, TargetAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
+//! let adc = Ads1x1x::new_ads1013(dev, TargetAddr::default());
 //! // do something...
 //!
 //! // get the I2C device back
@@ -102,20 +102,20 @@
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
-//! use ads1x1x::{Ads1x1x, SlaveAddr};
+//! use ads1x1x::{Ads1x1x, TargetAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let adc = Ads1x1x::new_ads1013(dev, SlaveAddr::Sda);
+//! let adc = Ads1x1x::new_ads1013(dev, TargetAddr::Sda);
 //! ```
 //!
 //! ### Make a one-shot measurement
 //! ```no_run
-//! use ads1x1x::{channel, Ads1x1x, SlaveAddr};
+//! use ads1x1x::{channel, Ads1x1x, TargetAddr};
 //! use linux_embedded_hal::I2cdev;
 //! use nb::block;
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let mut adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
+//! let mut adc = Ads1x1x::new_ads1013(dev, TargetAddr::default());
 //! let measurement = block!(adc.read(channel::DifferentialA0A1)).unwrap();
 //! println!("Measurement: {}", measurement);
 //! let _dev = adc.destroy_ads1013(); // get I2C device back
@@ -128,10 +128,10 @@
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
-//! use ads1x1x::{Ads1x1x, ModeChangeError, SlaveAddr};
+//! use ads1x1x::{Ads1x1x, ModeChangeError, TargetAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let adc = Ads1x1x::new_ads1013(dev, SlaveAddr::default());
+//! let adc = Ads1x1x::new_ads1013(dev, TargetAddr::default());
 //! match adc.into_continuous() {
 //!     Err(ModeChangeError::I2C(e, adc)) => /* mode change failed handling */ panic!(),
 //!     Ok(mut adc) => {
@@ -148,10 +148,10 @@
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
-//! use ads1x1x::{Ads1x1x, DataRate16Bit, SlaveAddr};
+//! use ads1x1x::{Ads1x1x, DataRate16Bit, TargetAddr};
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let mut adc = Ads1x1x::new_ads1115(dev, SlaveAddr::default());
+//! let mut adc = Ads1x1x::new_ads1115(dev, TargetAddr::default());
 //! adc.set_data_rate(DataRate16Bit::Sps860).unwrap();
 //! ```
 //!
@@ -160,17 +160,17 @@
 //! or goes above 1.5V in at least two consecutive conversions. Then the
 //! ALERT/RDY pin will be set high and it will be kept so until the
 //! measurement is read or an appropriate SMBus alert response is sent by
-//! the master.
+//! the controller.
 //!
 //! ```no_run
 //! use linux_embedded_hal::I2cdev;
 //! use ads1x1x::{
-//!     Ads1x1x, SlaveAddr, ComparatorQueue, ComparatorPolarity,
+//!     Ads1x1x, TargetAddr, ComparatorQueue, ComparatorPolarity,
 //!     ComparatorMode, ComparatorLatching, FullScaleRange
 //! };
 //!
 //! let dev = I2cdev::new("/dev/i2c-1").unwrap();
-//! let address = SlaveAddr::default();
+//! let address = TargetAddr::default();
 //! let mut adc = Ads1x1x::new_ads1015(dev, address);
 //! adc.set_comparator_queue(ComparatorQueue::Two).unwrap();
 //! adc.set_comparator_polarity(ComparatorPolarity::ActiveHigh).unwrap();
@@ -224,7 +224,7 @@ mod types;
 use crate::types::Config;
 pub use crate::types::{
     mode, Ads1x1x, ComparatorLatching, ComparatorMode, ComparatorPolarity, ComparatorQueue,
-    DataRate12Bit, DataRate16Bit, Error, FullScaleRange, ModeChangeError, SlaveAddr,
+    DataRate12Bit, DataRate16Bit, Error, FullScaleRange, ModeChangeError, TargetAddr,
 };
 
 mod private {

--- a/src/types.rs
+++ b/src/types.rs
@@ -117,9 +117,9 @@ pub enum ComparatorLatching {
     /// Latching
     ///
     /// The asserted ALERT/RDY pin remains latched until conversion data are
-    /// read by the master or an appropriate SMBus alert response is sent by
-    /// the master. The device responds with its address, and it is the lowest
-    /// address currently asserting the ALERT/RDY bus line.
+    /// read by the controller or an appropriate SMBus alert response is sent by
+    /// the controller. The device responds with its address, and it is the
+    /// lowest address currently asserting the ALERT/RDY bus line.
     Latching,
 }
 
@@ -160,11 +160,11 @@ pub enum FullScaleRange {
     Within0_256V,
 }
 
-/// A slave address.
+/// A target address.
 ///
 /// See [Table 4 in the datasheet](https://www.ti.com/lit/ds/symlink/ads1115.pdf#%5B%7B%22num%22%3A716%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C0%2C602.2%2C0%5D).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum SlaveAddr {
+pub enum TargetAddr {
     /// Address when the ADDR pin is connected to GND. (default)
     #[default]
     Gnd,
@@ -180,7 +180,7 @@ pub enum SlaveAddr {
     Scl,
 }
 
-impl SlaveAddr {
+impl TargetAddr {
     pub(crate) const fn bits(self) -> u8 {
         match self {
             Self::Gnd => 0b1001000,
@@ -235,19 +235,19 @@ pub struct Ads1x1x<I2C, IC, CONV, MODE> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{FullScaleRange, SlaveAddr};
+    use crate::{FullScaleRange, TargetAddr};
 
     #[test]
-    fn slave_addr_default() {
-        assert_eq!(0b100_1000, SlaveAddr::default().bits());
+    fn target_addr_default() {
+        assert_eq!(0b100_1000, TargetAddr::default().bits());
     }
 
     #[test]
-    fn slave_addr_bits() {
-        assert_eq!(0b100_1000, SlaveAddr::Gnd.bits());
-        assert_eq!(0b100_1001, SlaveAddr::Vdd.bits());
-        assert_eq!(0b100_1010, SlaveAddr::Sda.bits());
-        assert_eq!(0b100_1011, SlaveAddr::Scl.bits());
+    fn target_addr_bits() {
+        assert_eq!(0b100_1000, TargetAddr::Gnd.bits());
+        assert_eq!(0b100_1001, TargetAddr::Vdd.bits());
+        assert_eq!(0b100_1010, TargetAddr::Sda.bits());
+        assert_eq!(0b100_1011, TargetAddr::Scl.bits());
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use ads1x1x::{ic, mode, Ads1x1x, SlaveAddr};
+use ads1x1x::{ic, mode, Ads1x1x, TargetAddr};
 use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 
 #[allow(unused)]
@@ -70,7 +70,7 @@ macro_rules! impl_new_destroy {
     ($ic:ident, $create:ident, $destroy:ident, $conv:ty, $trans:ty, $iface:ty) => {
         #[allow(unused)]
         pub fn $create(transactions: &[$trans]) -> Ads1x1x<$iface, ic::$ic, $conv, mode::OneShot> {
-            Ads1x1x::$create(I2cMock::new(transactions), SlaveAddr::default())
+            Ads1x1x::$create(I2cMock::new(transactions), TargetAddr::default())
         }
 
         #[allow(unused)]


### PR DESCRIPTION
This bring the language in-line with [Rev. 7.0 of the 2C-bus specification and user manual ](https://www.nxp.com/docs/en/user-guide/UM10204.pdf).